### PR TITLE
Removed module name for AMD portability

### DIFF
--- a/src/jsonConverters.js
+++ b/src/jsonConverters.js
@@ -362,7 +362,7 @@
             geoJsonConverter: geoJsonConverter
         };
 
-        define('extras/jsonConverters', [], function() {
+        define([], function() {
 
             return module;
 


### PR DESCRIPTION
I've removed the module name so it's more portable when using the Dojo AMD loader.
